### PR TITLE
BUGFIX: MLrunner isnt using polling observer as expected

### DIFF
--- a/ml-runner/ml-runner.py
+++ b/ml-runner/ml-runner.py
@@ -374,7 +374,9 @@ if __name__ == '__main__':
     runner = MLRunner(listen_path, use_florence = use_florence)
 
     # Gotta use poll as the standard observer doesnt work on nfs
-    is_poll = not listen_path.startswith('/mnt/') or not listen_path.startswith('/Volumes/')
+    is_poll = not listen_path.startswith('/mnt/')
+    is_poll = not listen_path.startswith('/Volumes/') if is_poll else is_poll
+    
     observer = Observer() if is_poll else PollingObserver(timeout = 1.0)
     event_handler = MLRunnerHandler(runner)
 


### PR DESCRIPTION
In the work to try to make this work across OSs I introduced a bug causing the app to use the wrong type of observer. 
This fix addressed that. 